### PR TITLE
[#188665212] Changement de php_doc_array_style depreciated + ajout de blank_line_after_opening_tag PSR12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ jobs:
       matrix:
         include:
           - operating-system: 'ubuntu-latest'
+            php-version: '8.0'
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.1'
+          - operating-system: 'ubuntu-latest'
             php-version: '8.2'
-
           - operating-system: 'ubuntu-latest'
             php-version: '8.3'
-            PHP_CS_FIXER_IGNORE_ENV: 1
 
     name: PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ jobs:
       matrix:
         include:
           - operating-system: 'ubuntu-latest'
-            php-version: '8.0'
-
-          - operating-system: 'ubuntu-latest'
-            php-version: '8.1'
-
-          - operating-system: 'ubuntu-latest'
             php-version: '8.2'
 
           - operating-system: 'ubuntu-latest'

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,11 +1,14 @@
 <?php
 
-$config = new EditionsTissot\CS\Config\Config(83, true);
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+$config = new EditionsTissot\CS\Config\Config(83, true, true);
 $config
     ->addMoreRules([
         'declare_strict_types' => true,
     ])
     ->setRiskyAllowed(true)
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->getFinder()
     ->in([
         __DIR__ . '/src',

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+cs-fix:
+	vendor/bin/php-cs-fixer fix

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   ],
   "require": {
     "php": ">=8.0",
-    "friendsofphp/php-cs-fixer": "^3.49",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.20"
+    "friendsofphp/php-cs-fixer": "^3.65",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
   },
   "require-dev": {
-    "phpstan/phpstan": "^1.10"
+    "phpstan/phpstan": "^1.12"
   },
   "autoload": {
     "psr-4": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,10 +13,10 @@ class Config extends BaseConfig
     protected bool $customFixers;
 
     public function __construct(
-        int $phpVersion = 74,
+        int $phpVersion = 82,
         bool $customFixers = false
     ) {
-        parent::__construct('EditionsTissot PHP >= 7.4 config');
+        parent::__construct('EditionsTissot PHP >= 8.2 config');
         $this->phpVersion = $phpVersion;
         $this->customFixers = $customFixers;
         $this->registerCustomFixers(new CustomFixers\Fixers());
@@ -50,7 +50,7 @@ class Config extends BaseConfig
     {
         $rules = [
             '@DoctrineAnnotation' => true,
-            '@PHP81Migration' => true,
+            '@PHP82Migration' => true,
             '@PhpCsFixer' => true,
             '@PSR12' => true,
             '@Symfony' => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -56,6 +56,7 @@ class Config extends BaseConfig
             '@Symfony' => true,
             'array_indentation' => true,
             'align_multiline_comment' => true,
+            'blank_line_after_opening_tag' => true,
             'blank_line_before_statement' => [
                 'statements' => [
                     'declare',
@@ -69,6 +70,7 @@ class Config extends BaseConfig
             ],
             'concat_space' => ['spacing' => 'one'],
             'no_superfluous_phpdoc_tags' => true,
+            'phpdoc_array_type' => true,
             'phpdoc_line_span' => [
                 'property' => 'single',
                 'const' => 'single',
@@ -126,7 +128,6 @@ class Config extends BaseConfig
             CustomFixers\Fixer\NoUselessDirnameCallFixer::name() => true,
             CustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer::name() => true,
             CustomFixers\Fixer\NoUselessStrlenFixer::name() => true,
-            CustomFixers\Fixer\PhpdocArrayStyleFixer::name() => true,
             CustomFixers\Fixer\PhpdocNoSuperfluousParamFixer::name() => true,
             CustomFixers\Fixer\PhpdocSelfAccessorFixer::name() => true,
             CustomFixers\Fixer\PhpdocSingleLineVarFixer::name() => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -56,7 +56,6 @@ class Config extends BaseConfig
             '@Symfony' => true,
             'array_indentation' => true,
             'align_multiline_comment' => true,
-            'blank_line_after_opening_tag' => true,
             'blank_line_before_statement' => [
                 'statements' => [
                     'declare',
@@ -120,7 +119,6 @@ class Config extends BaseConfig
         return [
             CustomFixers\Fixer\CommentSurroundedBySpacesFixer::name() => true,
             CustomFixers\Fixer\ConstructorEmptyBracesFixer::name() => true,
-            CustomFixers\Fixer\DeclareAfterOpeningTagFixer::name() => true,
             CustomFixers\Fixer\MultilinePromotedPropertiesFixer::name() => true,
             CustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
             CustomFixers\Fixer\NoImportFromGlobalNamespaceFixer::name() => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -81,14 +81,6 @@ class Config extends BaseConfig
             'yoda_style' => true,
         ];
 
-        if ($this->phpVersion >= 80) {
-            $rules['@PHP80Migration'] = true;
-        }
-
-        if ($this->phpVersion >= 81) {
-            $rules['@PHP81Migration'] = true;
-        }
-
         if ($this->phpVersion >= 82) {
             $rules['@PHP82Migration'] = true;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace EditionsTissot\CS\Config;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,16 +11,13 @@ class Config extends BaseConfig
 {
     /** @var array<string, bool|mixed> */
     protected array $rules = [];
-    protected int $phpVersion;
-    protected bool $customFixers;
 
     public function __construct(
-        int $phpVersion = 82,
-        bool $customFixers = false
+        private int $phpVersion = 80,
+        private bool $customFixers = false,
+        private bool $enableRisky = false,
     ) {
-        parent::__construct('EditionsTissot PHP >= 8.2 config');
-        $this->phpVersion = $phpVersion;
-        $this->customFixers = $customFixers;
+        parent::__construct('EditionsTissot PHP >= 8.0 config');
         $this->registerCustomFixers(new CustomFixers\Fixers());
     }
 
@@ -31,7 +28,8 @@ class Config extends BaseConfig
     {
         return array_merge(
             $this->addDefaultRules(),
-            $this->customFixers ? $this->addCustomRules() : [],
+            $this->addRiskyRules(),
+            $this->addCustomRules(),
             $this->rules,
         );
     }
@@ -42,6 +40,7 @@ class Config extends BaseConfig
     public function addMoreRules(array $rules = []): self
     {
         $this->rules = array_merge($this->rules, $rules);
+
         return $this;
     }
 
@@ -52,12 +51,30 @@ class Config extends BaseConfig
     {
         $rules = [
             '@DoctrineAnnotation' => true,
-            '@PHP82Migration' => true,
-            '@PhpCsFixer' => true,
+            '@PER-CS2.0' => true,
+            '@PHP80Migration' => true,
             '@PSR12' => true,
+            '@PhpCsFixer' => true,
             '@Symfony' => true,
-            'array_indentation' => true,
-            'align_multiline_comment' => true,
+
+            // https://mlocati.github.io/php-cs-fixer-configurator/#version:3.65|configurator|fixer:phpdoc_line_span
+            'phpdoc_line_span' => [
+                'property' => 'single',
+                'const' => 'single',
+            ],
+
+            // https://mlocati.github.io/php-cs-fixer-configurator/#version:3.65|configurator|fixer:phpdoc_param_order
+            'phpdoc_param_order' => true,
+
+            // https://mlocati.github.io/php-cs-fixer-configurator/#version:3.65|configurator|fixer:phpdoc_to_comment
+            // Permet de faire un @var sur une seule ligne
+            'phpdoc_to_comment' => ['ignored_tags' => ['var']],
+
+            // https://mlocati.github.io/php-cs-fixer-configurator/#version:3.65|configurator|fixer:php_unit_test_class_requires_covers
+            'php_unit_test_class_requires_covers' => false,
+
+            'phpdoc_array_type' => true,
+
             'blank_line_before_statement' => [
                 'statements' => [
                     'declare',
@@ -65,23 +82,20 @@ class Config extends BaseConfig
                     'for',
                     'foreach',
                     'if',
+                    'phpdoc',
+                    'return',
                     'switch',
                     'try',
+                    'while',
                 ],
             ],
-            'concat_space' => ['spacing' => 'one'],
-            'no_superfluous_phpdoc_tags' => true,
-            'phpdoc_array_type' => true,
-            'phpdoc_line_span' => [
-                'property' => 'single',
-                'const' => 'single',
-            ],
-            'phpdoc_param_order' => true,
-            'phpdoc_summary' => false,
-            'phpdoc_to_comment' => ['ignored_tags' => ['var']],
-            'php_unit_test_class_requires_covers' => false,
-            'yoda_style' => true,
+
+            'single_line_empty_body' => true,
         ];
+
+        if ($this->phpVersion >= 81) {
+            $rules['@PHP81Migration'] = true;
+        }
 
         if ($this->phpVersion >= 82) {
             $rules['@PHP82Migration'] = true;
@@ -91,15 +105,31 @@ class Config extends BaseConfig
             $rules['@PHP83Migration'] = true;
         }
 
-        if ($this->getRiskyAllowed()) {
-            $rules = array_merge(
-                $rules,
-                [
-                    '@PSR12:risky' => true,
-                    '@Symfony:risky' => true,
-                    'no_unreachable_default_argument_value' => false,
-                ]
-            );
+        return $rules;
+    }
+
+    /**
+     * @return array<string, bool|mixed>
+     */
+    private function addRiskyRules(): array
+    {
+        if (!$this->enableRisky) {
+            return [];
+        }
+
+        $rules = [
+            '@PER-CS2.0:risky' => true,
+            '@PHP80Migration:risky' => true,
+            '@PSR12:risky' => true,
+            '@PhpCsFixer:risky' => true,
+            '@Symfony:risky' => true,
+
+            // https://mlocati.github.io/php-cs-fixer-configurator/#version:3.65|configurator|fixer:no_unreachable_default_argument_value
+            'no_unreachable_default_argument_value' => false,
+        ];
+
+        if ($this->phpVersion >= 82) {
+            $rules['@PHP82Migration:risky'] = true;
         }
 
         return $rules;
@@ -110,15 +140,22 @@ class Config extends BaseConfig
      */
     protected function addCustomRules(): array
     {
+        if (!$this->customFixers) {
+            return [];
+        }
+
         return [
             CustomFixers\Fixer\CommentSurroundedBySpacesFixer::name() => true,
-            CustomFixers\Fixer\ConstructorEmptyBracesFixer::name() => true,
+            CustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
             CustomFixers\Fixer\MultilinePromotedPropertiesFixer::name() => true,
             CustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
+            CustomFixers\Fixer\NoDuplicatedArrayKeyFixer::name() => true,
+            CustomFixers\Fixer\NoDuplicatedImportsFixer::name() => true,
             CustomFixers\Fixer\NoImportFromGlobalNamespaceFixer::name() => true,
             CustomFixers\Fixer\NoUselessCommentFixer::name() => true,
             CustomFixers\Fixer\NoUselessDirnameCallFixer::name() => true,
             CustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer::name() => true,
+            CustomFixers\Fixer\NoUselessParenthesisFixer::name() => true,
             CustomFixers\Fixer\NoUselessStrlenFixer::name() => true,
             CustomFixers\Fixer\PhpdocNoSuperfluousParamFixer::name() => true,
             CustomFixers\Fixer\PhpdocSelfAccessorFixer::name() => true,


### PR DESCRIPTION
+ Changement de php_doc_array_style depreciated 
+ Ajout de blank_line_after_opening_tag PSR12 (suppression de la règle DeclareAfterOpeningTagFixer)
+ PHP 8.2 min (Suppression du CI tests 8.0 + 8.1, mise à jour de la v min a 8.2)